### PR TITLE
feat: increase the prow chart version

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -7,7 +7,7 @@ dependencies:
   condition: prow.enabled
   name: prow
   repository: http://chartmuseum.jenkins-x.io
-  version: 0.0.925
+  version: 0.0.931
 - alias: lighthouse
   condition: lighthouse.enabled
   name: lighthouse


### PR DESCRIPTION
Increase the Prow chart version so it uses the latest pipelinerunner version.

Signed-off-by: Daniel Gozalo <dgozalo@cloudbees.com>