### PR TITLE
chore: store pipelineuser email

### DIFF
--- a/env/templates/dev-env.yaml
+++ b/env/templates/dev-env.yaml
@@ -33,6 +33,7 @@ spec:
     importMode: YAML
     kubeProvider: gke
     pipelineUsername: "{{ .Values.JenkinsXGitHub.username }}"
+    pipelineUserEmail: "{{ .Values.JenkinsXGitHub.email }}"
     promotionEngine: Prow
     prowConfig: Scheduler
     prowEngine: Tekton

--- a/env/values.tmpl.yaml
+++ b/env/values.tmpl.yaml
@@ -147,6 +147,7 @@ tekton:
 
 JenkinsXGitHub:
   username: "{{ .Parameters.pipelineUser.username }}"
+  email: "{{ .Parameters.pipelineUser.email }}"
   password: "{{ .Parameters.pipelineUser.token }}"
 
 {{- if .Requirements.ingress.tls }}


### PR DESCRIPTION
Signed-off-by: Mark Cox <markcox20@hotmail.com>

Store pipeline user email in dev environment CRD, so it can be used for git config in cluster

https://github.com/jenkins-x/jx/issues/5235