### PR TITLE
add missing apiVersion field

### DIFF
--- a/env/Chart.yaml
+++ b/env/Chart.yaml
@@ -1,3 +1,4 @@
+apiVersion: v1
 description: GitOps Environment for this Environment
 icon: https://www.cloudbees.com/sites/default/files/Jenkins_8.png
 maintainers:


### PR DESCRIPTION
It seems as of `2.15` Helm requires the field `apiVersion: v1` to be set in a `Chart.yaml`.

```
STEP: install-jenkins-x command: /bin/sh -c jx step helm apply --boot --remote --name jenkins-x --provider-values-dir ../kubeProviders in dir: env

Modified file /Users/joostvdg/Projects/Personal/Github/vasimos/jx/cjxd/gke/jxboot/cloudbees-jenkins-x-boot-config/env/Chart.yaml to set the chart to version 1
Ignoring templates/.gitignore
Applying the kubernetes overrides at ../kubeProviders/gke/values.tmpl.yaml
Verifying the helm requirements versions in dir: . using version stream URL: https://github.com/cloudbees/cloudbees-jenkins-x-versions.git and git ref: v0.0.15
error: failed to lint the chart '/var/folders/f_/mpwdv8s16r7_zt43r3r7k20w0000gn/T/jx-helm-apply-578543501/env': failed to run 'helm lint' command in directory '/var/folders/f_/mpwdv8s16r7_zt43r3r7k20w0000gn/T/jx-helm-apply-578543501/env', output: '==> Linting .
[ERROR] Chart.yaml: apiVersion is required

Error: 1 chart(s) linted, 1 chart(s) failed'
```