### PR TITLE
add missing apiVersion field

### DIFF
--- a/repositories/Chart.yaml
+++ b/repositories/Chart.yaml
@@ -1,3 +1,4 @@
+apiVersion: v1
 description: Source Repositories Chart
 maintainers:
 - name: Team


### PR DESCRIPTION
It seems as of 2.15 Helm requires the field apiVersion: v1 to be set in a Chart.yaml.