### PR TITLE
chore: Update ci.sh for import/qs with local creds

### DIFF
--- a/bdd/bdd.sh
+++ b/bdd/bdd.sh
@@ -19,10 +19,15 @@ export BUILD_NUMBER="$BUILD_ID"
 JX_HOME="/tmp/jxhome"
 KUBECONFIG="/tmp/jxhome/config"
 
-mkdir -p $JX_HOME
+# lets avoid the git/credentials causing confusion during the test
+export XDG_CONFIG_HOME=$JX_HOME
+
+mkdir -p $JX_HOME/git
 
 jx --version
-jx step git credentials
+
+# replace the credentials file with a single user entry
+echo "https://$GH_USERNAME:$GH_ACCESS_TOKEN@github.com" > $JX_HOME/git/credentials
 
 # setup GCP service account
 gcloud auth activate-service-account --key-file $GKE_SA


### PR DESCRIPTION
Once jenkins-x/jx#6199 is merged and that jx version is used here, import/create quickstart will fail without this change, so let's get ahead of things a bit. =)