### PR TITLE
feat: Add JXUI app by default.

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -21,3 +21,5 @@ dependencies:
 #- condition: chartmuseum.enabled
 #  name: chartmuseum
 #  repository: http://chartmuseum.jenkins-x.io
+- name: jx-app-ui
+  repository: http://chartmuseum.jenkins-x.io


### PR DESCRIPTION
Install JXUI app in CJXD by default.

As a **prerequisite** this PR requires `jx-app-ui` to be maintained within the version stream - the corresponding [PR](https://github.com/cloudbees/cloudbees-jenkins-x-versions/pull/207) must be merged first.